### PR TITLE
empty hash != hash not given, and apparently something on github's end changed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,6 @@ inputs:
     description: 'The stringified JSON body to be sent, if any.'
     required: false
     default: ''
-outputs:
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
Fixes issue #1 